### PR TITLE
Allow files that include config to also use argparse

### DIFF
--- a/examples/python/config.py
+++ b/examples/python/config.py
@@ -52,7 +52,7 @@ class EdgeGridConfig():
         		parser.add_argument('--' + argument)
         		arguments[argument] = config_values[argument]
         try:
-            args = parser.parse_args()
+            args = parser.parse_known_args()
         except:
             sys.exit()
         arguments = vars(args)


### PR DESCRIPTION
Currently, config.py completely prevents the use of argparse in any script that imports it.  This pull request changes config.py to only consume the arguments explicitly defined in its own file.

Test program:
```
import argparse

from config import EdgeGridConfig
config = EdgeGridConfig({"verbose":False},"default")

mparser = argparse.ArgumentParser()
mparser.add_argument("-a")
args = mparser.parse_args()
print("argument a is {}".format(args.a))
```
If we try to pass `-a`, config.py eats it:
```
$ python test-arg.py  -a A
usage: test-arg.py [-h] [--verbose] [--debug] [--config_file CONFIG_FILE]
                   [--config_section CONFIG_SECTION]
test-arg.py: error: unrecognized arguments: -a A
$
```
If we change config.py to only parse known arguments ( using `parser.parse_known_args()` ), then other parsers can get their input.
```
$ python test-arg.py  -a A
argument a is A
$
```
